### PR TITLE
fix(Windows): Enable console output with env variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -188,6 +188,8 @@ else()
       lib/glad/glad.c
       src/Platform/SDL/Window.cpp
       src/Platform/SystemInfo.windows.cpp
+      src/Platform/Windows/Console.cpp
+      src/Platform/Windows/Console.h
       tools/make.ps1
     )
   elseif(APPLE)

--- a/src/Common/Logging.h
+++ b/src/Common/Logging.h
@@ -37,15 +37,15 @@
 #       define LOGE(...) LOG_F("ERROR", __VA_ARGS__, '\n')
 #       define LOGF(...) LOG_F("FATAL", __VA_ARGS__, '\n')
 #   endif  // _MSC_VER
-#   ifdef NDEBUG
-#       define LOGD(...) static_cast<void>(0)
-#       define LOGI(...) static_cast<void>(0)
-#       define LOGW(...) static_cast<void>(0)
+#   ifdef _MSC_VER
+#       define LOGD(fmt, ...) LOG_F("DEBUG", fmt, __VA_ARGS__)
+#       define LOGI(fmt, ...) LOG_F("INFO", fmt, __VA_ARGS__)
+#       define LOGW(fmt, ...) LOG_F("WARN", fmt, __VA_ARGS__)
 #   else
-#       ifdef _MSC_VER
-#           define LOGD(fmt, ...) LOG_F("DEBUG", fmt, __VA_ARGS__)
-#           define LOGI(fmt, ...) LOG_F("INFO", fmt, __VA_ARGS__)
-#           define LOGW(fmt, ...) LOG_F("WARN", fmt, __VA_ARGS__)
+#       ifdef NDEBUG
+#           define LOGD(...) static_cast<void>(0)
+#           define LOGI(...) static_cast<void>(0)
+#           define LOGW(...) static_cast<void>(0)
 #       else
 #           define LOGD(...) LOG_F("DEBUG", __VA_ARGS__, '\n')
 #           define LOGI(...) LOG_F("INFO", __VA_ARGS__, '\n')

--- a/src/Platform/SDL/main.cpp
+++ b/src/Platform/SDL/main.cpp
@@ -17,6 +17,7 @@
 #       pragma comment(linker, "/SUBSYSTEM:WINDOWS")
 #   endif
 #   include "Graphics/OpenGL.h"
+#   include "Platform/Windows/Console.h"
 #endif
 
 #include "Common/Functional.h"
@@ -71,7 +72,7 @@ auto main(int argc, char* argv[]) -> int
 #endif
 
 #ifdef RAINBOW_OS_WINDOWS
-    SetConsoleOutputCP(CP_UTF8);
+    rainbow::windows::Console console;
 #endif
 
     const rainbow::Config config;

--- a/src/Platform/Windows/Console.cpp
+++ b/src/Platform/Windows/Console.cpp
@@ -1,0 +1,37 @@
+// Copyright (c) 2010-present Bifrost Entertainment AS and Tommy Nguyen
+// Distributed under the MIT License.
+// (See accompanying file LICENSE or copy at http://opensource.org/licenses/MIT)
+
+#include "Platform/Windows/Console.h"
+
+#include <cstring>
+#include <iostream>
+
+#include <Windows.h>
+
+using rainbow::windows::Console;
+
+Console::Console()
+{
+    SetConsoleOutputCP(CP_UTF8);
+
+    auto use_console = std::getenv("RAINBOW_CONSOLE");
+    if (use_console == nullptr || strcmp(use_console, "1") != 0)
+        return;
+
+    is_attached_ = AllocConsole();
+    if (!is_attached_)
+        return;
+
+    freopen_s(&stdout_handle_, "CONOUT$", "w", stdout);
+    std::cout.clear();
+}
+
+Console::~Console()
+{
+    if (stdout_handle_ != nullptr)
+        fclose(stdout_handle_);
+
+    if (is_attached_)
+        FreeConsole();
+}

--- a/src/Platform/Windows/Console.h
+++ b/src/Platform/Windows/Console.h
@@ -1,0 +1,24 @@
+// Copyright (c) 2010-present Bifrost Entertainment AS and Tommy Nguyen
+// Distributed under the MIT License.
+// (See accompanying file LICENSE or copy at http://opensource.org/licenses/MIT)
+
+#ifndef PLATFORM_WINDOWS_CONSOLE_H_
+#define PLATFORM_WINDOWS_CONSOLE_H_
+
+#include <cstdio>
+
+namespace rainbow::windows
+{
+    class Console
+    {
+    public:
+        Console();
+        ~Console();
+
+    private:
+        bool is_attached_ = false;
+        FILE* stdout_handle_ = nullptr;
+    };
+}  // namespace rainbow::windows
+
+#endif


### PR DESCRIPTION
Setting `RAINBOW_CONSOLE=1` will now open a console on release builds.

Resolves #532.

### Test Plan

1. Make a release build of Rainbow, e.g. with `MinSizeRel`
2. Starting `rainbow.exe` should not open a console.
3. Starting `rainbow.exe` with the environment variable set should open a console.
    - From Bash:
        ```sh
        cd build/windows
        RAINBOW_CONSOLE=1 MinSizeRel/rainbow ../../js
        ```
    - From Command Prompt:
        ```
        set RAINBOW_CONSOLE=1
        cd build\windows
        MinSizeRel\rainbow ..\..\js
        ```