### PR TITLE
ci(Windows): Fix build breakage with recent image update

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,8 @@ on:
     branches:
       - master
   pull_request:
+env:
+  WINDOWS_10_SDK: "10.0.18362.0"
 jobs:
   Windows:
     strategy:
@@ -31,7 +33,7 @@ jobs:
         submodules: true
     - name: Build
       run: |
-        cmake -DCOVERAGE=1 -DUNIT_TESTS=1 -DUSE_HEIMDALL=1 -DUSE_PHYSICS=1 -A x64 ../..
+        cmake -DCMAKE_SYSTEM_VERSION=$WINDOWS_10_SDK -DCOVERAGE=1 -DUNIT_TESTS=1 -DUSE_HEIMDALL=1 -DUSE_PHYSICS=1 -A x64 ../..
         cmake --build . --parallel --config $CONFIGURATION -- /verbosity:minimal
       shell: bash
       working-directory: build/windows
@@ -54,7 +56,7 @@ jobs:
         submodules: true
     - name: Build
       run: |
-        cmake -DUSE_HEIMDALL=1 -DUSE_PHYSICS=1 -A x64 ../..
+        cmake -DCMAKE_SYSTEM_VERSION=$WINDOWS_10_SDK -DUSE_HEIMDALL=1 -DUSE_PHYSICS=1 -A x64 ../..
         cmake --build . --parallel --config $CONFIGURATION -- /verbosity:minimal
       shell: bash
       working-directory: build/windows


### PR DESCRIPTION
A recent image update broke Windows builds. It looks like an older
Windows 10 SDK is being used.