### PR TITLE
ci(android): sdkmanager requires Java 8

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -149,6 +149,10 @@ jobs:
       ANDROID_CMAKE_VERSION: 3.10.2.4988404
       ANDROID_SDK_TOOLS_VERSION: 4333796
     steps:
+    - name: Set up JDK
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
     - name: Checkout
       uses: actions/checkout@v2
       with:
@@ -165,7 +169,8 @@ jobs:
       env:
         TERM: dumb
       run: |
-        gradle build
+        gradle wrapper --gradle-version 6.8.3
+        ./gradlew build
       working-directory: build/android
   iOS:
     runs-on: macos-latest

--- a/build/android/build.gradle
+++ b/build/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.3'
+        classpath 'com.android.tools.build:gradle:4.1.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/build/android/gradle/wrapper/gradle-wrapper.properties
+++ b/build/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Gradle 7 also recently got pushed to the CIs so we need to ensure we're on a compatible version.